### PR TITLE
require('something')('something-else') not transformed correctly

### DIFF
--- a/test/fixtures/cjs-complex.after.js
+++ b/test/fixtures/cjs-complex.after.js
@@ -1,0 +1,2 @@
+import debug from 'debug';
+var log = debug('some:log');

--- a/test/fixtures/cjs-complex.before.js
+++ b/test/fixtures/cjs-complex.before.js
@@ -1,0 +1,1 @@
+var log = require('debug')('some:log');

--- a/test/transforms/cjs.js
+++ b/test/transforms/cjs.js
@@ -24,4 +24,11 @@ describe('CJS transform', function() {
     var result = cjsTransform({ source: src }, { jscodeshift: jscodeshift });
     assert.equal(result, expectedSrc);
   });
+
+  it('should convert a tricky require() usage ', function() {
+    var src = fs.readFileSync(path.resolve(__dirname, '../fixtures/cjs-complex.before.js')).toString();
+    var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/cjs-complex.after.js')).toString();
+    var result = cjsTransform({ source: src }, { jscodeshift: jscodeshift });
+    assert.equal(result, expectedSrc);
+  });
 });


### PR DESCRIPTION
(This PR is just to demonstrate the issue. The test fails.)

Input:

``` js
var log = require('debug')('some:log');
```

Output:

``` js
import log from 'some:log';
var log = debug('some:log');
```

It's a tricky case to convert, but I guess the idea output would be something like:

``` js
import debug from 'debug';
var log = debug('some:log');
```
