### PR TITLE
Move runtime libs to dependencies map in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
   },
   "contributors": ["Jamis Charles", "Jamund Ferguson"],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "jscodeshift": "^0.3.8",
+    "recast": "^0.10.34"
+  },
   "devDependencies": {
     "eslint": "^1.0.0",
-    "jscodeshift": "^0.3.8",
-    "mocha": "^2.3.3",
-    "recast": "^0.10.34"
+    "mocha": "^2.3.3"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
If you install the package now for usage, runtime dependencies (`recast` & `jscodeshift`) won't get installed because these are in [`devDependecies` map](https://github.com/npm/npm/blob/2e3776bf5676bc24fec6239a3420f377fe98acde/doc/files/package.json.md#devdependencies) - so I moved it to `dependencies`.