### PR TITLE
Use correct module name in jscodeshift command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ js code from ES5 to ES6 using [jscodeshift](https://github.com/facebook/jscodesh
 
 1. `npm install -g jscodeshift`
 2. `npm install 5to6-codemod`
-3. `jscodeshift -t node_modules/es6-codemod/transforms/[transform].js [files]`
+3. `jscodeshift -t node_modules/5to6-codemod/transforms/[transform].js [files]`
 4. Review changes via `git diff`. Keep what you want, throw it out if you don't. Magic!
 
 ## Transforms


### PR DESCRIPTION
From this history it looks like the module was renamed in https://github.com/5to6/5to6-codemod/commit/fcf238295af0b1e182b8988770f4c0f39ce13c99