### PR TITLE
var { module1, module2 } = require('module3) => import { module1, module2 } from 'module3';

### DIFF
--- a/test/fixtures/cjs.after.js
+++ b/test/fixtures/cjs.after.js
@@ -16,3 +16,4 @@ var jamis = 'bar', bar, foo = 'bar';
 
 import {routeTo} from '../routeHelper';
 import {pluck as fetch} from '../someUtil';
+import {includes, pick} from 'lodash';

--- a/test/fixtures/cjs.before.js
+++ b/test/fixtures/cjs.before.js
@@ -17,3 +17,4 @@ var jamis = 'bar',
 
 var routeTo = require('../routeHelper').routeTo;
 var fetch = require('../someUtil').pluck;
+var {includes, pick} = require('lodash');

--- a/test/transforms/cjs.js
+++ b/test/transforms/cjs.js
@@ -22,7 +22,7 @@ describe('CJS transform', function() {
     var src = fs.readFileSync(path.resolve(__dirname, '../fixtures/cjs.before.js')).toString();
     var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/cjs.after.js')).toString();
     var result = cjsTransform({ source: src }, { jscodeshift: jscodeshift });
-    assert.equal(result, expectedSrc);
+    assert.equal(result.trim(), expectedSrc.trim());
   });
 
   it('should convert empty files', function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -42,6 +42,14 @@ describe('util.getPropsFromRequire(ast)', function(){
     assert.deepEqual(result, expected);
   });
 
+
+  it('var { includes, pick } = require(\'lodash\') -> {variableName = [\'includes\', \'pick\'], moduleName: \'lodash\'}', function() {
+    var ast = toAST('var { includes, pick } = require(\'lodash\');')[0]; // returns an array of statements
+    var result = utils.getPropsFromRequire(ast);
+    var expected = { variableName: ['includes', 'pick'], moduleName: 'lodash' };
+
+    assert.deepEqual(result, expected);
+  });
 });
 
 describe('util.createImportStatement(moduleName [, variableName])', function(){
@@ -74,8 +82,12 @@ describe('util.createImportStatement(moduleName [, variableName])', function(){
     assert.deepEqual(result, expected);
   });
 
+  it('-> `import {includes, omit} from \'lodash\'` when passed 2 params (second one being an array of strings)', function() {
+    var result = toString(utils.createImportStatement('lodash', ['includes', 'omit']));
+    var expected = 'import {includes, omit} from \'lodash\';';
 
-
+    assert.deepEqual(result, expected);
+  });
 });
 
 // unroll single var statements?
@@ -143,4 +155,3 @@ function toString(ast) {
 function toAST(code) {
   return recast.parse(code).program.body;
 }
-


### PR DESCRIPTION
Also, I took a look at `master` and three tests are failing off the bat. This PR only adds one error which seems to be wrong:
```
1) CJS transform should convert require('jquery') -> import 'jquery' :

      AssertionError: '// CJS top comment\n\nimport jamis from \'jquery\';\nimport $ from \'jquery\';\nimport $ from \'jquery\';\nimport \'something\' == '// CJS top comment\n\nimport jamis from \'jquery\';\nimport $ from \'jquery\';\nimport $ from \'jquery\';\nimport \'something\'
      + expected - actual

       var jamis = 'bar', bar, foo = 'bar';

       import {routeTo} from '../routeHelper';
       import {pluck as fetch} from '../someUtil';
      -import {includes, pick} from 'lodash';
      +import {includes, pick} from 'lodash';

      at Context.<anonymous> (test/transforms/cjs.js:25:12)
```

It is complaining about the last line even though they look totally indentical. I'm thinking maybe a whitespace issue?