### PR TITLE
Fix exports.js exporting unnamed functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "jscodeshift": "^0.3.28",
+    "jscodeshift": "^0.3.30",
     "recast": "^0.11.14"
   },
   "devDependencies": {

--- a/test/fixtures/cjs.after.js
+++ b/test/fixtures/cjs.after.js
@@ -15,6 +15,6 @@ import $ from 'jquery';
 // some comment
 var jamis = 'bar', bar, foo = 'bar';
 
-import {routeTo} from '../routeHelper';
-import {pluck as fetch} from '../someUtil';
-import {includes, pick} from 'lodash';
+import { routeTo } from '../routeHelper';
+import { pluck as fetch } from '../someUtil';
+import { includes, pick } from 'lodash';

--- a/test/fixtures/exports.after.js
+++ b/test/fixtures/exports.after.js
@@ -2,10 +2,14 @@
 // should be export default
 export default { a: 'a' };
 
-// should be `export let` or `export function`
+// should be `export let things`
 export let things = "a";
 
+// should be `export function thunks`
 export function thunks() {};
+
+// should be `export function thunks2`
+export function thunks2() {};
 
 // more or less the same as above
 export default function thing() {};

--- a/test/fixtures/exports.after.js
+++ b/test/fixtures/exports.after.js
@@ -5,11 +5,14 @@ export default { a: 'a' };
 // should be `export let things`
 export let things = "a";
 
-// should be `export function thunks`
-export function thunks() {};
+// should be `export function thunks1`
+export function thunks1() {};
 
 // should be `export function thunks2`
 export function thunks2() {};
+
+// should be `export function thunks3`
+export function thunks3() {};
 
 // more or less the same as above
 export default function thing() {};

--- a/test/fixtures/exports.before.js
+++ b/test/fixtures/exports.before.js
@@ -3,10 +3,12 @@ module.exports = { a: 'a' };
 
 // should be `export let things`
 exports.things = "a";
-// should be `export function thunks`
-exports.thunks = function thunks() {};
+// should be `export function thunks1`
+exports.thunks1 = function thunks1() {};
 // should be `export function thunks2`
 exports.thunks2 = function() {};
+// should be `export function thunks3`
+exports.thunks3 = function thunkName() {};
 
 // more or less the same as above
 module.exports = function thing() {};

--- a/test/fixtures/exports.before.js
+++ b/test/fixtures/exports.before.js
@@ -1,9 +1,12 @@
 // should be export default
 module.exports = { a: 'a' };
 
-// should be `export let` or `export function`
+// should be `export let things`
 exports.things = "a";
+// should be `export function thunks`
 exports.thunks = function thunks() {};
+// should be `export function thunks2`
+exports.thunks2 = function() {};
 
 // more or less the same as above
 module.exports = function thing() {};

--- a/test/utils.js
+++ b/test/utils.js
@@ -70,21 +70,21 @@ describe('util.createImportStatement(moduleName [, variableName])', function(){
 
   it('-> `import {pluck} from \'jquery\'` when passed 3 params', function() {
     var result = toString(utils.createImportStatement('jquery', 'pluck', 'pluck'));
-    var expected = 'import {pluck} from \'jquery\';';
+    var expected = 'import { pluck } from \'jquery\';';
 
     assert.deepEqual(result, expected);
   });
 
   it('-> `import {fetch as pluck} from \'jquery\'` when passed 3 params', function() {
     var result = toString(utils.createImportStatement('jquery', 'fetch', 'pluck'));
-    var expected = 'import {pluck as fetch} from \'jquery\';';
+    var expected = 'import { pluck as fetch } from \'jquery\';';
 
     assert.deepEqual(result, expected);
   });
 
   it('-> `import {includes, omit} from \'lodash\'` when passed 2 params (second one being an array of strings)', function() {
     var result = toString(utils.createImportStatement('lodash', ['includes', 'omit']));
-    var expected = 'import {includes, omit} from \'lodash\';';
+    var expected = 'import { includes, omit } from \'lodash\';';
 
     assert.deepEqual(result, expected);
   });

--- a/transforms/exports.js
+++ b/transforms/exports.js
@@ -28,7 +28,9 @@ module.exports = function(file, api) {
 		var declaration;
 		if (p.value.right.type === 'FunctionExpression') {
 			declaration = p.value.right;
-			declaration.id = declaration.id || {type: 'Identifier', name: propertyName};
+      declaration.id = declaration.id || {type: 'Identifier'};
+      // we want the exported function to take the name of the exports.propertyName, even if it implies fn renaming
+      declaration.id.name = propertyName;
 		} else {
 			declaration = j.variableDeclaration('let', [declator]);
 		}

--- a/transforms/exports.js
+++ b/transforms/exports.js
@@ -23,10 +23,12 @@ module.exports = function(file, api) {
 	 * Move `module.exports.thing` to `export let thing`
 	 */
 	function exportsToExport(p) {
-		var declator = j.variableDeclarator(j.identifier(p.value.left.property.name), p.value.right);
+		var propertyName = p.value.left.property.name;
+		var declator = j.variableDeclarator(j.identifier(propertyName), p.value.right);
 		var declaration;
 		if (p.value.right.type === 'FunctionExpression') {
 			declaration = p.value.right;
+			declaration.id = declaration.id || {type: 'Identifier', name: propertyName};
 		} else {
 			declaration = j.variableDeclaration('let', [declator]);
 		}


### PR DESCRIPTION
Hi,

`exports.thunks2 = function() {};` is currently exported as `export function() {};` which is illegal

My PR is an attempt to fix this issue. I'm a total JSCodeShift/Recast beginner, but my PR pass the fixture test I created so it looks safe.

Also note that I upgraded to latest JSCodeShift and fixed non-passing unit-tests due to code-style preferences (expected `import {module1,module2}`, actual `import { module1, module2 }`)
