### PR TITLE
Update no-strict to only replace removed leading comments

### DIFF
--- a/test/fixtures/no-strict-closure.after.js
+++ b/test/fixtures/no-strict-closure.after.js
@@ -1,0 +1,4 @@
+/**
+ * My comment here
+ */
+define(function(require) {})

--- a/test/fixtures/no-strict-closure.before.js
+++ b/test/fixtures/no-strict-closure.before.js
@@ -1,0 +1,6 @@
+/**
+ * My comment here
+ */
+define(function(require) {
+    'use strict';
+})

--- a/test/transforms/no-strict.js
+++ b/test/transforms/no-strict.js
@@ -24,4 +24,10 @@ describe('no-strict transform', function() {
 		var result = nsTransform({ source: src }, { jscodeshift: jscodeshift });
 		assert.equal(result, expectedSrc);
 	});
+	it('should not duplicate leading comment ', function() {
+		var src = fs.readFileSync(path.resolve(__dirname, '../fixtures/no-strict-closure.before.js')).toString();
+		var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/no-strict-closure.after.js')).toString();
+		var result = nsTransform({ source: src }, { jscodeshift: jscodeshift });
+		assert.equal(result, expectedSrc);
+	});
 });

--- a/transforms/no-strict.js
+++ b/transforms/no-strict.js
@@ -9,16 +9,20 @@ module.exports = function(file, api) {
 	var j = api.jscodeshift;
 	var root = j(file.source);
 	var leadingComment = root.find(j.Program).get('body', 0).node.leadingComments;
+	var replaceLeadingComment = false;
 
 	// remove all "use strict" statements
 	root.find(j.ExpressionStatement).forEach(function(item) {
 		if (item.value.expression.value === 'use strict') {
+			replaceLeadingComment = replaceLeadingComment || item.parent.value.type === 'Program';
 			j(item).remove();
 		}
 	});
 
-	// re-add comment to to the top
-	root.get().node.comments = leadingComment;
+	// re-add comment to to the top if it was removed
+	if (replaceLeadingComment) {
+		root.get().node.comments = leadingComment;
+	}
 
 	return root.toSource({ quote: 'single' });
 };


### PR DESCRIPTION
Currently the `no-strict` transform blindly resets the leading comment.
This can cause the root comment to be duplicated, when `use strict`
is inside a closure i.e.

```js
/**
 * My comment here
 */
define(function(require) {
    'use strict';
})
```
```js
/**
 * My comment here
 */
/**
 * My comment here
 */
define(function(require) {});
```

This patch only resets the leading comment if the `use strict` is at the
root level of the file.