### PR TITLE
Fix tests failing due to recast change

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "jscodeshift": "^0.3.28",
-    "recast": "^0.11.14"
+    "recast": "^0.11.18"
   },
   "devDependencies": {
     "eslint": "^1.0.0",

--- a/test/fixtures/cjs.after.js
+++ b/test/fixtures/cjs.after.js
@@ -15,6 +15,6 @@ import $ from 'jquery';
 // some comment
 var jamis = 'bar', bar, foo = 'bar';
 
-import {routeTo} from '../routeHelper';
-import {pluck as fetch} from '../someUtil';
-import {includes, pick} from 'lodash';
+import { routeTo } from '../routeHelper';
+import { pluck as fetch } from '../someUtil';
+import { includes, pick } from 'lodash';

--- a/test/utils.js
+++ b/test/utils.js
@@ -70,21 +70,21 @@ describe('util.createImportStatement(moduleName [, variableName])', function(){
 
   it('-> `import {pluck} from \'jquery\'` when passed 3 params', function() {
     var result = toString(utils.createImportStatement('jquery', 'pluck', 'pluck'));
-    var expected = 'import {pluck} from \'jquery\';';
+    var expected = 'import { pluck } from \'jquery\';';
 
     assert.deepEqual(result, expected);
   });
 
   it('-> `import {fetch as pluck} from \'jquery\'` when passed 3 params', function() {
     var result = toString(utils.createImportStatement('jquery', 'fetch', 'pluck'));
-    var expected = 'import {pluck as fetch} from \'jquery\';';
+    var expected = 'import { pluck as fetch } from \'jquery\';';
 
     assert.deepEqual(result, expected);
   });
 
   it('-> `import {includes, omit} from \'lodash\'` when passed 2 params (second one being an array of strings)', function() {
     var result = toString(utils.createImportStatement('lodash', ['includes', 'omit']));
-    var expected = 'import {includes, omit} from \'lodash\';';
+    var expected = 'import { includes, omit } from \'lodash\';';
 
     assert.deepEqual(result, expected);
   });


### PR DESCRIPTION
recast@v0.11.18 changed how the output whitespace in curly braces
(benjamn/recast@4899a70d4b). This change has caused some test to fail.

This PR sets the minimum version recast to where the breakage occurred
and fixed the failing tests.

Discovered this whilst working on #25.