### PR TITLE
Smarter AMD export

### DIFF
--- a/test/fixtures/amd.after.js
+++ b/test/fixtures/amd.after.js
@@ -3,6 +3,8 @@
  */
 console.log('a');
 export default {};
+export default {};
+console.log('last statement');
 
 /**
  * Hunger Games is real

--- a/test/fixtures/amd.before.js
+++ b/test/fixtures/amd.before.js
@@ -9,6 +9,11 @@ define(function() {
 	return {};
 });
 
+define(function() {
+	return {};
+	console.log('last statement');
+});
+
 /**
  * Hunger Games is real
  */

--- a/transforms/amd.js
+++ b/transforms/amd.js
@@ -11,14 +11,19 @@ module.exports = function(file, api) {
 
     /**
      * Convert an `return` to `export default`.
-     * @param ast - Function body AST (Array)
+     * @param body - Function body AST (Array)
      */
     function returnToExport(body) {
         var exportStatement;
-        var possibleReturn = body[body.length - 1];
-        if (possibleReturn && possibleReturn.type === 'ReturnStatement') {
+        var possibleReturn = body.filter(function (node) {
+            return node.type === 'ReturnStatement'
+        }).reduce(function (prev, cur) {
+            return cur;
+        }, null);
+
+        if (possibleReturn && body.indexOf(possibleReturn) != -1) {
             exportStatement = j.exportDeclaration(true, possibleReturn.argument);
-            body[body.length - 1] = exportStatement;
+            body[body.indexOf(possibleReturn)] = exportStatement;
         }
         return body;
     }


### PR DESCRIPTION
Currently the AMD transform only attempts to replace the trailing
node in the definition iif it's a `ReturnStatement`. If the `return`
statement appears else where in the definition no `export` is
produced.

With this patch the candidate `return` node is the last `return`
node that appears in the definition's body.