### PR TITLE
Improve leading comment duplication for cjs transform

### DIFF
--- a/test/fixtures/cjs-comment.after.js
+++ b/test/fixtures/cjs-comment.after.js
@@ -1,5 +1,3 @@
 // hey look this has no require()s anywhere!
 
-// hey look this has no require()s anywhere!
-
 console.log('hello world!');

--- a/transforms/cjs.js
+++ b/transforms/cjs.js
@@ -7,7 +7,7 @@ var util = require('../utils/main');
 module.exports = function(file, api) {
     var j = api.jscodeshift;
     var root = j(file.source);
-    var leadingComment = root.find(j.Program).get('body', 0).node.leadingComments;
+    var originalLeadingComment = root.find(j.Program).get('body', 0).node.leadingComments;
 
     // migrate away all the imports
     root.find(j.CallExpression, { callee: { name: 'require' } }) // find require() function calls
@@ -65,7 +65,10 @@ module.exports = function(file, api) {
         });
 
     // re-add comment to to the top
-    root.get().node.comments = leadingComment;
+    var currentLeadingComment = root.find(j.Program).get('body', 0).node.leadingComments;
+    if (!currentLeadingComment && originalLeadingComment) {
+        root.get().node.comments = originalLeadingComment;
+    }
 
     return root.toSource({ quote: 'single' });
 };


### PR DESCRIPTION
This updates the cjs transform to essentially check that it's not
adding a leading comment if one already exists.

Tested this on a decent sized codebase

```
0 errors
336 unmodified
0 skipped
0 ok
Time elapsed: 6.994seconds
```