### PR TITLE
Now using `export const` instead of `export let`

### DIFF
--- a/test/fixtures/cjs-object.after.js
+++ b/test/fixtures/cjs-object.after.js
@@ -2,4 +2,5 @@
 import { x } from 'var-obj-stacked-comment';
 
 import { x } from 'var-obj-no-comment';
-import { x } from 'var-obj-inline-comment'; // stacked comment
+import { x } from 'var-obj-inline-comment'; // inline comment
+import foo from 'bar';

--- a/test/fixtures/cjs-object.before.js
+++ b/test/fixtures/cjs-object.before.js
@@ -1,4 +1,5 @@
 // stacked comment
 var x = require('var-obj-stacked-comment').x;
 var x = require('var-obj-no-comment').x;
-var x = require('var-obj-inline-comment').x; // stacked comment
+var x = require('var-obj-inline-comment').x; // inline comment
+var foo = require('bar').default;

--- a/test/fixtures/exports.after.js
+++ b/test/fixtures/exports.after.js
@@ -1,22 +1,22 @@
 // should be export default
 export default { a: 'a' };
 
-// should be `export let` or `export function`
-export let things = "a";
+// should be `export const` or `export function`
+export const things = "a";
 
-export let thunks = function thunks() {};
-export let thunks2 = function() {};
+export const thunks = function thunks() {};
+export const thunks2 = function() {};
 
 // more or less the same as above
 export default function thing() {};
 
-export let horse = "morse";
+export const horse = "morse";
 
 // in this case we can mix `default` and the others
 export default function() {};
 
-export let CONSTANT_NAME = 'HOUSE';
-export let isAnnoying = true;
+export const CONSTANT_NAME = 'HOUSE';
+export const isAnnoying = true;
 
 // A common enough case that is a bit weird... will need to be two lines
 var House = function() {};

--- a/test/fixtures/exports.before.js
+++ b/test/fixtures/exports.before.js
@@ -1,7 +1,7 @@
 // should be export default
 module.exports = { a: 'a' };
 
-// should be `export let` or `export function`
+// should be `export const` or `export function`
 exports.things = "a";
 exports.thunks = function thunks() {};
 exports.thunks2 = function() {};

--- a/test/utils.js
+++ b/test/utils.js
@@ -68,6 +68,13 @@ describe('util.createImportStatement(moduleName [, variableName])', function(){
     assert.deepEqual(result, expected);
   });
 
+  it('-> `import foo from \'bar\'` when passed 3 params where propName is default', function() {
+    var result = toString(utils.createImportStatement('bar', 'foo', 'default'));
+    var expected = 'import foo from \'bar\';';
+
+    assert.deepEqual(result, expected);
+  });
+
   it('-> `import {pluck} from \'jquery\'` when passed 3 params', function() {
     var result = toString(utils.createImportStatement('jquery', 'pluck', 'pluck'));
     var expected = 'import { pluck } from \'jquery\';';

--- a/transforms/exports.js
+++ b/transforms/exports.js
@@ -20,11 +20,11 @@ module.exports = function(file, api) {
 	}
 
 	/**
-	 * Move `module.exports.thing` to `export let thing`
+	 * Move `module.exports.thing` to `export const thing`
 	 */
 	function exportsToExport(p) {
 		var declator = j.variableDeclarator(j.identifier(p.value.left.property.name), p.value.right);
-		var declaration = j.variableDeclaration('let', [declator]);
+		var declaration = j.variableDeclaration('const', [declator]);
 		var exportDecl = j.exportDeclaration(false, declaration);
 		// console.log('[module.]exports.thing', util.toString(p), util.toString(exportDecl));
 		exportDecl.comments = p.parentPath.value.comments;

--- a/utils/main.js
+++ b/utils/main.js
@@ -69,7 +69,7 @@ var util = {
       variable = j.importDefaultSpecifier(nameIdentifier);
 
       // if propName, use destructuring `import {pluck} from 'underscore'`
-      if (propName) {
+      if (propName && propName !== 'default') {
         idIdentifier = j.identifier(propName);
         variable = j.importSpecifier(idIdentifier, nameIdentifier); // if both are same, one is dropped...
       }


### PR DESCRIPTION
- Fixed export transform to use `export const` instead of `export let`
- Updated cjs transform to handle `var x = require(‘y’).default` to `import x from ‘y’;`

Here's Airbnb's style guide and eslint-plugin-import reporting on why:
https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md
https://github.com/airbnb/javascript#modules--no-mutable-exports