### PR TITLE
New transformation: named export generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Our transforms will automatically distinguish and pass through Recast config key
 - `cjs` - Transforms CommonJS style `require()` calls to ES6 `import` statements
 - `no-strict` - Removes "use strict" statements
 - `exports` - Move CommonJS style `module.exports` statements to ES6 `export` statements
+- `named-export-generation` - Adds named exports corresponding to default export object keys. Only valid for ES6 modules exporting an object as the default export.
 - `let` - Replace all `var` calls to use `let`
 - `simple-arrow` - Replace all function expressions with a body of a sole return statement into arrow functions
 

--- a/test/fixtures/named-export-generation/declared-mutated.after.js
+++ b/test/fixtures/named-export-generation/declared-mutated.after.js
@@ -1,0 +1,25 @@
+let exported;
+exported = {
+    a: 14,
+
+    b: function(user) {
+        console.warn('user', user);
+    },
+
+    c: {
+        sample: 42
+    }
+};
+exported.d = 'some mutated value';
+exported.e = {};
+exported.f = function(input) { console.warn('input', input); }
+export default exported;
+
+export const {
+    a,
+    b,
+    c,
+    d,
+    e,
+    f
+} = exported;

--- a/test/fixtures/named-export-generation/declared-mutated.before.js
+++ b/test/fixtures/named-export-generation/declared-mutated.before.js
@@ -1,0 +1,16 @@
+let exported;
+exported = {
+    a: 14,
+
+    b: function(user) {
+        console.warn('user', user);
+    },
+
+    c: {
+        sample: 42
+    }
+};
+exported.d = 'some mutated value';
+exported.e = {};
+exported.f = function(input) { console.warn('input', input); }
+export default exported;

--- a/test/fixtures/named-export-generation/declared.after.js
+++ b/test/fixtures/named-export-generation/declared.after.js
@@ -1,0 +1,18 @@
+const exported = {
+    a: 14,
+
+    b: function(user) {
+        console.warn('user', user);
+    },
+
+    c: {
+        sample: 42
+    }
+};
+export default exported;
+
+export const {
+    a,
+    b,
+    c
+} = exported;

--- a/test/fixtures/named-export-generation/declared.before.js
+++ b/test/fixtures/named-export-generation/declared.before.js
@@ -1,0 +1,12 @@
+const exported = {
+    a: 14,
+
+    b: function(user) {
+        console.warn('user', user);
+    },
+
+    c: {
+        sample: 42
+    }
+};
+export default exported;

--- a/test/fixtures/named-export-generation/expression.after.js
+++ b/test/fixtures/named-export-generation/expression.after.js
@@ -1,0 +1,23 @@
+const exported = {};
+let exported2, exported3;
+var exported4;
+
+const exported5 = {
+    a: 14,
+
+    b: function(user) {
+        console.warn('user', user);
+    },
+
+    c: {
+        sample: 42
+    }
+};
+
+export default exported5;
+
+export const {
+    a,
+    b,
+    c
+} = exported5;

--- a/test/fixtures/named-export-generation/expression.before.js
+++ b/test/fixtures/named-export-generation/expression.before.js
@@ -1,0 +1,15 @@
+const exported = {};
+let exported2, exported3;
+var exported4;
+
+export default {
+    a: 14,
+
+    b: function(user) {
+        console.warn('user', user);
+    },
+
+    c: {
+        sample: 42
+    }
+};

--- a/test/transforms/named-export-generation.js
+++ b/test/transforms/named-export-generation.js
@@ -1,0 +1,40 @@
+// TODO: See if we should decouple the actual rule well enough that it can be run from both the command line and the
+// node interface (test)
+/**
+ * DEPS
+ */
+var jscodeshift = require('jscodeshift');
+var fs = require('fs');
+var path = require('path');
+var assert = require('assert');
+
+/**
+ * LOCAL DEPS
+ */
+var namedExportsTransform = require('../../transforms/named-export-generation');
+
+/**
+ * TESTS
+ *
+ */
+describe('Named exports generation transform', function() {
+  it(
+    'should generate named exports for an exported declarator',
+    helper.bind(this, 'declared')
+  );
+  it(
+    'should generate named exports for an exported declarator that has been mutated',
+    helper.bind(this, 'declared-mutated')
+  );
+  it(
+    'should generate named exports for an exported object expression',
+    helper.bind(this, 'expression')
+  );
+})
+
+function helper(name) {
+  var src = fs.readFileSync(path.resolve(__dirname, '../fixtures/named-export-generation/' + name + '.before.js')).toString();
+  var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/named-export-generation/' + name + '.after.js')).toString();
+  var result = namedExportsTransform({ source: src }, { jscodeshift: jscodeshift });
+  assert.equal(result, expectedSrc);
+}

--- a/transforms/named-export-generation.js
+++ b/transforms/named-export-generation.js
@@ -5,7 +5,7 @@
 
 var util = require('../utils/main');
 
-module.exports = function(file, api) {
+module.exports = function(file, api, options) {
 	var j = api.jscodeshift;
 	var root = j(file.source);
 	var firstNode = root.find(j.Program).get('body', 0).node
@@ -174,6 +174,5 @@ module.exports = function(file, api) {
 		firstNode2.comments = firstNode.leadingComments
 	}
 
-	// FIXME: Use config instead of hardcoded value
-	return root.toSource({ quote: 'single' });
+	return root.toSource(util.getRecastConfig(options));
 };

--- a/transforms/named-export-generation.js
+++ b/transforms/named-export-generation.js
@@ -1,0 +1,179 @@
+/**
+ * named-export-generation - Given a default export object, generate named exports
+ * corresponding to object properties.
+ */
+
+var util = require('../utils/main');
+
+module.exports = function(file, api) {
+	var j = api.jscodeshift;
+	var root = j(file.source);
+	var firstNode = root.find(j.Program).get('body', 0).node
+
+	/**
+	 * Add named exports for default exported declaration
+	 */
+	function addNamedExports(exportRef) {
+		var defaultExportName;
+		var objectExpressions = [];
+
+		// Find default exported object expression
+		// ex. export default { ... };
+		if (exportRef.value.declaration.type === 'ObjectExpression') {
+			// TODO: Write function to generate exported declarator name
+			defaultExportName = generateDefaultExportName()
+			var replacementExport = j.exportDefaultDeclaration(j.identifier(defaultExportName));
+			var replacementDeclaration = j.variableDeclaration('const', [
+				j.variableDeclarator(j.identifier(defaultExportName), exportRef.value.declaration)
+			]);
+			if (exportRef.value.comments && exportRef.value.comments.length > 0) {
+				replacementDeclaration.comments = exportRef.value.comments;
+			}
+			exportRef.insertBefore(replacementDeclaration);
+			exportRef = j(exportRef).replaceWith(replacementExport).__paths[0];
+		} else {
+			defaultExportName = exportRef.value.declaration.name
+		}
+
+
+		// Find default exported declaration
+		// ex. const analytics = { ... };
+		//     export default analytics;
+		root.find(j.VariableDeclarator, {
+			id: {
+				type: 'Identifier',
+				name: defaultExportName
+			},
+			init: {
+				type: 'ObjectExpression'
+			}
+		}).forEach(function(vdRef) {
+			var objectExpression = vdRef.value.init;
+			if (objectExpression !== null) {
+				objectExpressions.push(objectExpression);
+			}
+		});
+
+		// Find default exported VariableDeclarator modified by ExpressionStatement
+		// ex. let analytics = { ... };      // Initialized
+		//     analytics = { ... };          // Updated to different value
+		//     analytics.someKey = 'horse';  // Updated to different value
+		//     export default analytics;
+		var mutatedProps = {};
+		root.find(j.ExpressionStatement, {
+			expression: {
+				operator: '=',
+				left: {
+					name: defaultExportName,
+					type: 'Identifier'
+				},
+				right: {
+					type: 'ObjectExpression'
+				}
+			}
+		}).forEach(function(esRef) {
+			var objectExpression = esRef.value.expression.right
+			objectExpression.properties.forEach(function(prop) {
+				mutatedProps[prop.key.name] = prop
+			});
+		});
+		root.find(j.ExpressionStatement, {
+			expression: {
+				operator: '=',
+				left: {
+					object: {
+						name: defaultExportName
+					},
+					type: 'MemberExpression'
+				}
+			}
+		}).forEach(function(esRef) {
+			var name = esRef.value.expression.left.property.name
+			var prop = j.property('init', j.identifier(name), j.identifier(name));
+			prop.shorthand = true;
+			mutatedProps[name] = prop;
+		});
+		if (Object.keys(mutatedProps).length > 0) {
+			var newObjectExpression = j.objectExpression(
+				Object.keys(mutatedProps).map(function(key) {
+					return mutatedProps[key]
+				})
+			)
+			objectExpressions.push(newObjectExpression)
+		}
+
+		// Convert object expressions into named export declarations and insert into tree
+		objectExpressions.filter(function(objectExpression) {
+			return 'properties' in objectExpression && objectExpression.properties.length > 0;
+		}).map(function(objectExpression) {
+			return generateNamedExportDeclaration(exportRef, defaultExportName, objectExpression);
+		}).forEach(function(exportNamedDeclaration) {
+			exportRef.insertAfter(exportNamedDeclaration);
+		});
+	}
+
+  function generateDefaultExportName() {
+    var prefix = 'exported';
+    var index = 2;
+    var name = prefix;
+    while (root.find(j.Identifier, { name: name }).length > 0) {
+      name = prefix + index;
+      index++;
+    }
+    return name;
+  }
+
+  function generateNamedExportDeclaration(exportRef, defaultExportName, objectExpression) {
+    const exportNames = objectExpression.properties.map(function(prop) {
+      return prop.key.name
+    });
+    const properties = exportNames.filter(function(name) {
+      return shouldCreateNamedExport(defaultExportName, name)
+    }).map(function(name) {
+      const prop = j.property('init', j.identifier(name), j.identifier(name));
+      prop.shorthand = true;
+      return prop;
+    });
+    const exportNamedDeclaration = j.exportNamedDeclaration(
+      j.variableDeclaration('const',[
+        j.variableDeclarator(
+          j.objectPattern(properties),
+          exportRef.value.declaration
+        )
+      ])
+    );
+    return exportNamedDeclaration;
+  }
+
+  function shouldCreateNamedExport(defaultExportName, exportName) {
+    const isAlreadyExportedInDeclaration = root.find(j.Property, {
+      value: {
+        name: exportName
+      }
+    }).filter(function(r) {
+      return util.hasParentOfType(r, 'ExportNamedDeclaration');
+    }).length > 0;
+    const isAlreadyExported = root.find(j.VariableDeclarator, {
+      id: { name: exportName },
+      init: {
+        object: { name: defaultExportName },
+        property: { name: exportName }
+      }
+    }).filter(function (r) {
+      return util.hasParentOfType(r, 'ExportNamedDeclaration');
+    }).length > 0;
+    const shouldCreateExport = !(isAlreadyExported || isAlreadyExportedInDeclaration);
+    return shouldCreateExport;
+  }
+
+	root.find(j.ExportDefaultDeclaration).forEach(addNamedExports);
+
+	// re-add comment to to the top if necessary
+	var firstNode2 = root.find(j.Program).get('body', 0).node
+	if (firstNode !== firstNode2) {
+		firstNode2.comments = firstNode.leadingComments
+	}
+
+	// FIXME: Use config instead of hardcoded value
+	return root.toSource({ quote: 'single' });
+};

--- a/utils/main.js
+++ b/utils/main.js
@@ -233,6 +233,22 @@ var util = {
     return util.getConfig(options, util.getDefaultRecastConfig(), function(key) {
       return util.isRecastArg(key);
     })
+  },
+
+  findParentOfType: function(node, type) {
+      // traverse up the tree until end, or you find a matching type
+      while (node.parentPath) {
+          node = node.parentPath;
+          if (node.value.type === type) {
+              return node;
+          }
+      }
+
+      return false;
+  },
+
+  hasParentOfType: function(node, type) {
+    return util.findParentOfType(node, type) !== false;
   }
 };
 


### PR DESCRIPTION
Addresses #34. 

If the default export is an object (e.g. `export default { ... }`), this transform will add named exports corresponding to each property of the the object. It will create a new declaration for the exported object if the default export was expressed with an object literal. If the exported object has been mutated after its initialization, this transform will try to capture all keys associated with the object. Unfortunately, this implementation allows for collision between the generated named export declarators and existing declarators. 

This transformation aims to enhance compatibility between CommonJS and ES2015 module notations, which can be especially useful for a large codebase migrating from CommonJS to ES2015 notation. (As I mentioned in #34 , some people are opting to use a transpiler plugin like [babel-plugin-add-module-exports](https://github.com/59naga/babel-plugin-add-module-exports) to ease the transition.)

I've provided examples of the transformation below. 

## Declared Default Export

**module.before.js**:
```javascript
const exported = {
  value1: 1,
  value2: 2,
};
export default exported;
```

**module.after.js**
```javascript
const exported = {
  value1: 1,
  value2: 2,
};
export default exported;
export const {
  value1,
  value2,
} = exported;
```

## Object Literal Default Export

**module.before.js**:
```javascript
export default {
  value1: 1,
  value2: 2,
};
```

**module.after.js**
```javascript
const exported = {
  value1: 1,
  value2: 2,
};
export default exported;
export const {
  value1,
  value2,
} = exported;
```

## Mutated Default Export

**module.before.js**:
```javascript
const exported = {
  value1: 1,
};
exported.value2 = 2;
export default exported;
```

**module.after.js**
```javascript
const exported = {
  value1: 1,
};
exported.value2 = 2;
export default exported;
export const {
  value1,
  value2,
} = exported;
```