### PR TITLE
changed cjs, export transforms and added import-cleanup

### DIFF
--- a/test/fixtures/cjs-declaration.after.js
+++ b/test/fixtures/cjs-declaration.after.js
@@ -4,6 +4,7 @@ import x from 'var-stacked-comment';
 import x from 'var-no-comment';
 import x from 'var-inline-comment'; // with inline comment
 import { x, y } from 'var-decomposition';
+import { x as z, y as a } from 'var-renamed-decomposition';
 import y from 'multi-var-y';
 import z from 'multi-var-z';
 import $ from 'multi-var-$';

--- a/test/fixtures/cjs-declaration.before.js
+++ b/test/fixtures/cjs-declaration.before.js
@@ -3,6 +3,7 @@ var x = require('var-stacked-comment');
 var x = require('var-no-comment');
 var x = require('var-inline-comment'); // with inline comment
 var { x, y } = require('var-decomposition');
+var { x: z, y: a } = require('var-renamed-decomposition');
 var x = 'x',
     y = require('multi-var-y'),
     z = require('multi-var-z'),

--- a/test/fixtures/exports/keyed.after.js
+++ b/test/fixtures/exports/keyed.after.js
@@ -9,6 +9,6 @@ export const horse = "morse";
 
 function foo () {}
 function bar () {}
-export { foo, bar };
+export { foo, bar, world };
 function world () {}
 export const hello = world;

--- a/test/fixtures/exports/keyed.after.js
+++ b/test/fixtures/exports/keyed.after.js
@@ -6,3 +6,8 @@ export const things = "a";
 export const thunks = function thunks() {};
 export const thunks2 = function() {};
 export const horse = "morse";
+
+function foo () {
+
+}
+export { foo };

--- a/test/fixtures/exports/keyed.after.js
+++ b/test/fixtures/exports/keyed.after.js
@@ -7,7 +7,8 @@ export const thunks = function thunks() {};
 export const thunks2 = function() {};
 export const horse = "morse";
 
-function foo () {
-
-}
-export { foo };
+function foo () {}
+function bar () {}
+export { foo, bar };
+function world () {}
+export const hello = world;

--- a/test/fixtures/exports/keyed.before.js
+++ b/test/fixtures/exports/keyed.before.js
@@ -7,7 +7,9 @@ exports.thunks2 = function() {};
 
 module.exports.horse = "morse";
 
-function foo () {
-
-}
-module.exports.foo = foo
+function foo () {}
+module.exports.foo = foo;
+function bar () {}
+module.exports.bar = bar;
+function world () {}
+module.exports.hello = world;

--- a/test/fixtures/exports/keyed.before.js
+++ b/test/fixtures/exports/keyed.before.js
@@ -6,3 +6,8 @@ exports.thunks = function thunks() {};
 exports.thunks2 = function() {};
 
 module.exports.horse = "morse";
+
+function foo () {
+
+}
+module.exports.foo = foo

--- a/test/fixtures/exports/keyed.before.js
+++ b/test/fixtures/exports/keyed.before.js
@@ -11,5 +11,6 @@ function foo () {}
 module.exports.foo = foo;
 function bar () {}
 module.exports.bar = bar;
+exports.world = world
 function world () {}
 module.exports.hello = world;

--- a/test/fixtures/import-cleanup/common.after.js
+++ b/test/fixtures/import-cleanup/common.after.js
@@ -1,0 +1,2 @@
+import * as React from 'react';
+import { default as React, PropTypes, createClass, PropType as Props, default as React1 } from 'react';

--- a/test/fixtures/import-cleanup/common.before.js
+++ b/test/fixtures/import-cleanup/common.before.js
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import React from 'react';
+import { PropTypes } from 'react';
+import { createClass } from 'react';
+import { PropTypes, createClass } from 'react';
+import { PropType as Props } from 'react';
+import { default as React } from 'react';
+import { default as React1 } from 'react';

--- a/test/transforms/exports.js
+++ b/test/transforms/exports.js
@@ -36,10 +36,6 @@ describe('Exports transform', function() {
     'should convert module.exports = (...) -> export default (...)',
     helper.bind(this, 'default')
   );
-  it(
-    'should convert module.exports.thing -> export const thing',
-    helper.bind(this, 'keyed')
-  );
 });
 
 function helper(name) {

--- a/test/transforms/import-cleanup.js
+++ b/test/transforms/import-cleanup.js
@@ -1,0 +1,16 @@
+var jscodeshift = require('jscodeshift');
+var fs = require('fs');
+var path = require('path');
+var assert = require('assert');
+var importCleanup = require('../../transforms/import-cleanup');
+
+describe('import-cleanup transform', function() {
+  it('should transform', helper.bind(undefined, 'common'));
+});
+
+function helper(name) {
+  var src = fs.readFileSync(path.resolve(__dirname, '../fixtures/import-cleanup/' + name + '.before.js')).toString();
+  var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/import-cleanup/' + name + '.after.js')).toString();
+  var result = importCleanup({ source: src }, { jscodeshift: jscodeshift });
+  assert.equal(result, expectedSrc);
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -44,10 +44,18 @@ describe('util.getPropsFromRequire(ast)', function(){
   });
 
 
-  it('var { includes, pick } = require(\'lodash\') -> {variableName = [\'includes\', \'pick\'], moduleName: \'lodash\'}', function() {
+  it('var { includes, pick } = require(\'lodash\') -> {variableName: [\'includes\', \'pick\'], moduleName: \'lodash\' propName: [\'includes\', \'pick\']}', function() {
     var ast = toAST('var { includes, pick } = require(\'lodash\');')[0]; // returns an array of statements
     var result = utils.getPropsFromRequire(ast);
-    var expected = { variableName: ['includes', 'pick'], moduleName: 'lodash' };
+    var expected = { variableName: ['includes', 'pick'], moduleName: 'lodash', propName: ['includes', 'pick'] };
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('var { includes: foo } = require(\'lodash\') -> {variableName: [\'includes\'], moduleName: \'lodash\', propName: [\'foo\']}', function() {
+    var ast = toAST('var { includes: foo } = require(\'lodash\');')[0]; // returns an array of statements
+    var result = utils.getPropsFromRequire(ast);
+    var expected = { variableName: ['includes'], moduleName: 'lodash', propName: ['foo'] };
 
     assert.deepEqual(result, expected);
   });
@@ -92,6 +100,20 @@ describe('util.createImportStatement(moduleName [, variableName])', function(){
 
   it('-> `import {includes, omit} from \'lodash\'` when passed 2 params (second one being an array of strings)', function() {
     var result = toString(utils.createImportStatement('lodash', ['includes', 'omit']));
+    var expected = 'import { includes, omit } from \'lodash\';';
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('-> `import {includes as foo, omit as bar} from \'lodash\'` when passed 2 array params', function() {
+    var result = toString(utils.createImportStatement('lodash', ['includes', 'omit'], ['foo', 'bar']));
+    var expected = 'import { includes as foo, omit as bar } from \'lodash\';';
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('-> `import {includes, omit} from \'lodash\'` when passed 2 array params with the same values', function() {
+    var result = toString(utils.createImportStatement('lodash', ['includes', 'omit'], ['includes', 'omit']));
     var expected = 'import { includes, omit } from \'lodash\';';
 
     assert.deepEqual(result, expected);

--- a/transforms/exports.js
+++ b/transforms/exports.js
@@ -23,9 +23,14 @@ module.exports = function(file, api, options) {
 	 * Move `module.exports.thing` to `export const thing`
 	 */
 	function exportsToExport(p) {
-		var declator = j.variableDeclarator(j.identifier(p.value.left.property.name), p.value.right);
-		var declaration = j.variableDeclaration('const', [declator]);
-		var exportDecl = j.exportDeclaration(false, declaration);
+		var exportDecl
+		if (p.value.left.property.name === p.value.right.name) {
+			exportDecl = j.exportDeclaration(false, null, [j.exportSpecifier(p.value.right, p.value.right)])
+		} else {
+			var declator = j.variableDeclarator(j.identifier(p.value.left.property.name), p.value.right);
+			var declaration = j.variableDeclaration('const', [declator]);
+			exportDecl = j.exportDeclaration(false, declaration);
+		}
 		// console.log('[module.]exports.thing', util.toString(p), util.toString(exportDecl));
 		exportDecl.comments = p.parentPath.value.comments;
 		j(p.parentPath).replaceWith(exportDecl);

--- a/transforms/import-cleanup.js
+++ b/transforms/import-cleanup.js
@@ -1,0 +1,55 @@
+/**
+ * import-cleanup - Combines and dedupes duplicate imports
+ */
+
+var util = require('../utils/main');
+
+module.exports = function transformer(file, api, options) {
+  const j = api.jscodeshift;
+
+  var sourceLookup = {}
+  return j(file.source)
+    .find(j.ImportDeclaration)
+    // ignore import * as ...
+    .filter(p => {
+      return p.parent.node.type === 'Program'
+        && p.get('specifiers', 0, 'type').value !== 'ImportNamespaceSpecifier'
+    })
+    .forEach(p => {
+        var source = p.get('source', 'value').value
+        var existingImport = sourceLookup[source]
+
+        if (!existingImport) {
+          sourceLookup[source] = p
+          return
+        }
+
+        var specifiers = dedupe(normalize(existingImport, j).concat(normalize(p, j)))
+        var updatedImport = j.importDeclaration(specifiers, p.value.source)
+        j(existingImport).replaceWith(updatedImport)
+        j(p).remove()
+    })
+    .toSource(util.getRecastConfig(options));
+}
+
+function normalize (importDecl, j) {
+  return importDecl.value.specifiers.map(specifier => {
+    const localName = specifier.local.name
+    const importedName = specifier.imported ? specifier.imported.name : 'default'
+    return j.importSpecifier(j.identifier(importedName), j.identifier(localName))
+  })
+}
+
+function dedupe (specifiers) {
+  var added = {}
+  var output = []
+
+  specifiers.forEach(specifier => {
+    var localName = specifier.local.name
+    if (added[localName]) return
+    output.push(specifier)
+    added[localName] = true
+  })
+
+  return output
+}

--- a/utils/main.js
+++ b/utils/main.js
@@ -58,8 +58,9 @@ var util = {
 
     // multiple variable names indicates a destructured import
     if (Array.isArray(variableName)) {
-      var variableIds = variableName.map(function(v) {
-        return j.importSpecifier(j.identifier(v), j.identifier(v));
+      var variableIds = variableName.map(function(v, i) {
+        var prop = Array.isArray(propName) && propName[i] ? propName[i] : v
+        return j.importSpecifier(j.identifier(v), j.identifier(prop));
       });
 
       declaration = j.importDeclaration(variableIds, j.literal(moduleName));
@@ -136,9 +137,11 @@ var util = {
       // var { includes, pick } = require('lodash');
       } else if (declarator.id.type === 'ObjectPattern') {
         var modules = [];
+        propName = [];
 
         declarator.id.properties.forEach(function(p) {
           modules.push(p.key.name);
+          propName.push(p.value.name);
         });
 
         variableName = modules;


### PR DESCRIPTION
Sorry, the right thing to do would have been to create multiple PRs for this change but I figured I'd share the love since I just used this update to convert our entire codebase.

## Enhanced cjs

Added support for renamed decomposition.

#### Before
```js
var { x: y, z: a } = require(‘foo’)
```

#### After
```js
import { x as y, z as a } from ‘foo’
```

## Enhanced exports

Added export aggregation. Until now, the following conversion happened `module.export.foo = foo` -> `export const foo = foo`. This broke [no-redeclare](http://eslint.org/docs/rules/no-redeclare) and  [no-user-before-define](http://eslint.org/docs/rules/no-use-before-define) for our codebase.

#### Before
```js
module.export.foo = foo
module.export.bar = bar
module.export.baz = baz
```

#### After
```js
export { foo, bar, baz }
```

## Introduced `import-cleanup` script

This script was introduced to deal with [no-duplicate-imports](http://eslint.org/docs/rules/no-duplicate-imports) which eslint didn't care about enforcing for requires. In the future, this script could be enhanced to handle sorting.

#### Before
```js
import * as foo from 'bar'
import React from 'react';
import { PropTypes } from 'react';
import { createClass } from 'react';
```

#### After
```js
import * as foo from 'bar'
import { default as React, PropTypes, createClass } from 'react'
```