### PR TITLE
Better handle edge cases for named export transformation

### DIFF
--- a/test/fixtures/named-export-generation/ignore.after.js
+++ b/test/fixtures/named-export-generation/ignore.after.js
@@ -1,0 +1,12 @@
+const exported = {
+    ['a']: 14,
+
+    ['b']: function(user) {
+        console.warn('user', user);
+    },
+
+    ['c']: {
+        sample: 42
+    }
+};
+export default exported;

--- a/test/fixtures/named-export-generation/ignore.before.js
+++ b/test/fixtures/named-export-generation/ignore.before.js
@@ -1,0 +1,12 @@
+const exported = {
+    ['a']: 14,
+
+    ['b']: function(user) {
+        console.warn('user', user);
+    },
+
+    ['c']: {
+        sample: 42
+    }
+};
+export default exported;

--- a/test/fixtures/named-export-generation/references.after.js
+++ b/test/fixtures/named-export-generation/references.after.js
@@ -1,0 +1,26 @@
+const aSource = 14,
+    z = 28;
+
+function b(user) {
+    console.warn('user', user);
+}
+
+function cFunction(foo, bar) {
+    return bar, foo;
+}
+
+const exported = {
+    a: aSource,
+
+    b: b,
+
+    c: cFunction,
+
+    d: 42,
+};
+export default exported;
+export { aSource as a, b, cFunction as c };
+
+export const {
+    d
+} = exported;

--- a/test/fixtures/named-export-generation/references.before.js
+++ b/test/fixtures/named-export-generation/references.before.js
@@ -1,0 +1,21 @@
+const aSource = 14,
+    z = 28;
+
+function b(user) {
+    console.warn('user', user);
+}
+
+function cFunction(foo, bar) {
+    return bar, foo;
+}
+
+const exported = {
+    a: aSource,
+
+    b: b,
+
+    c: cFunction,
+
+    d: 42,
+};
+export default exported;

--- a/test/transforms/named-export-generation.js
+++ b/test/transforms/named-export-generation.js
@@ -30,6 +30,14 @@ describe('Named exports generation transform', function() {
     'should generate named exports for an exported object expression',
     helper.bind(this, 'expression')
   );
+	it(
+    'should generate named exports if object keys are references',
+    helper.bind(this, 'references')
+  );
+	it(
+    'should ignore computed property keys for an exported object expression',
+    helper.bind(this, 'ignore')
+  );
 })
 
 function helper(name) {


### PR DESCRIPTION
Currently, the named export transformation improperly handles instances where 
- property values are variable references
- property keys are calculated values (ex. `['a']`) 

This change adds improved handling for both cases and adds corresponding unit tests.

Cheers! :)