### PR TITLE
Enable keyed exports fixture for exports test

### DIFF
--- a/test/transforms/exports.js
+++ b/test/transforms/exports.js
@@ -36,6 +36,10 @@ describe('Exports transform', function() {
     'should convert module.exports = (...) -> export default (...)',
     helper.bind(this, 'default')
   );
+  it(
+    'should convert module.exports.thing -> export const thing',
+    helper.bind(this, 'keyed')
+  );
 });
 
 function helper(name) {


### PR DESCRIPTION
This PR enables a test with the export transformation that covers keyed exports. (The fixture is already there - just not being processed.)