### PR TITLE
Add CommonJS import hoisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Our transforms will automatically distinguish and pass through Recast config key
 
 - `amd` - Transforms AMD style modules to ES6 `import`/`export`
 - `cjs` - Transforms CommonJS style `require()` calls to ES6 `import` statements
+	- This transformation accepts the following option flags:
+		- `hoist`: Enables hoisting require statements to the top
 - `no-strict` - Removes "use strict" statements
 - `exports` - Move CommonJS style `module.exports` statements to ES6 `export` statements
 - `named-export-generation` - Adds named exports corresponding to default export object keys. Only valid for ES6 modules exporting an object as the default export.

--- a/test/fixtures/cjs/called.after.js
+++ b/test/fixtures/cjs/called.after.js
@@ -4,15 +4,15 @@ import aFactory from 'var-stacked-comment';
 const a = aFactory();
 import bFactory from 'var-no-comment';
 const b = bFactory('arg for b');
-import cFactory from 'var-inline-comment'; // with inline comment
-const c = cFactory({ some: 'arg' });
+import cFactory from 'var-inline-comment';
+const c = cFactory({ some: 'arg' }); // with inline comment
 import deFactory from 'var-decomposition';
 const { d, e } = deFactory();
-import jFactory from 'multi-var-j';
-const j = jFactory();
-import hFactory from 'multi-var-h';
-const h = hFactory();
 import gFactory from 'multi-var-g';
 const g = gFactory();
+import hFactory from 'multi-var-h';
+const h = hFactory();
+import jFactory from 'multi-var-j';
+const j = jFactory();
 
 var f = 'x', unassigned, i = 'bar';

--- a/test/fixtures/cjs/comments.after.js
+++ b/test/fixtures/cjs/comments.after.js
@@ -19,3 +19,10 @@ import NoResults from 'no-results';
 import actions from 'actions';
 import Placeholder from './placeholder';
 import { mapPostStatus as mapStatus } from 'lib/route';
+
+/**
+ * Random dependencies
+ */
+import someLib from 'lib/main';
+
+import otherLib from 'lib/other';

--- a/test/fixtures/cjs/comments.before.js
+++ b/test/fixtures/cjs/comments.before.js
@@ -17,3 +17,8 @@ var Fetcher = require( 'components/list-fetcher' ),
 	actions = require( 'actions' ),
 	Placeholder = require( './placeholder' ),
 	mapStatus = require( 'lib/route' ).mapPostStatus;
+/**
+ * Random dependencies
+ */
+const someLib = require( 'lib/main' );
+const otherLib = require( 'lib/other' );

--- a/test/fixtures/cjs/hoist.after.js
+++ b/test/fixtures/cjs/hoist.after.js
@@ -1,0 +1,30 @@
+import trackScrollPage from 'lib/track-scroll-page';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, userHasHistory } from 'reader/controller-helper';
+import route from 'lib/route';
+import feedStreamFactory from 'lib/feed-stream-store';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import RecommendedForYou from 'reader/recommendations/for-you';
+
+import a from 'import-outside';
+import 'import-expression-inside-function';
+import 'import-expression-inside-if';
+import 'import-expression-inside-else-if';
+import 'import-expression-inside-else';
+import 'import-expression-inside-for';
+import 'import-expression-inside-while';
+import b from 'import-inside-function';
+import d from 'import-inside-if';
+import e from 'import-inside-else-if';
+import f from 'import-inside-else';
+import g from 'import-inside-for';
+import h from 'import-inside-while';
+
+function block() {
+  var c = true ? require('import-expression-ternary-if') : require('import-expression-ternary-else')
+  if (true) {} else if (false) {} else {}
+
+  for (var i = 0; i < 10; i++) {}
+
+  while (true) {}
+}

--- a/test/fixtures/cjs/hoist.before.js
+++ b/test/fixtures/cjs/hoist.before.js
@@ -1,0 +1,36 @@
+import trackScrollPage from 'lib/track-scroll-page';
+import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
+import { ensureStoreLoading, trackPageLoad, trackUpdatesLoaded, userHasHistory } from 'reader/controller-helper';
+import route from 'lib/route';
+import feedStreamFactory from 'lib/feed-stream-store';
+import { renderWithReduxStore } from 'lib/react-helpers';
+import RecommendedForYou from 'reader/recommendations/for-you';
+
+var a = require('import-outside');
+
+function block() {
+  require('import-expression-inside-function');
+  var b = require('import-inside-function');
+
+  var c = true ? require('import-expression-ternary-if') : require('import-expression-ternary-else')
+  if (true) {
+    require('import-expression-inside-if');
+    var d = require('import-inside-if');
+  } else if (false) {
+    require('import-expression-inside-else-if');
+    var e = require('import-inside-else-if');
+  } else {
+    require('import-expression-inside-else');
+    var f = require('import-inside-else');
+  }
+
+  for (var i = 0; i < 10; i++) {
+    require('import-expression-inside-for');
+    var g = require('import-inside-for');
+  }
+
+  while (true) {
+    require('import-expression-inside-while');
+    var h = require('import-inside-while');
+  }
+}

--- a/test/transforms/cjs.js
+++ b/test/transforms/cjs.js
@@ -25,6 +25,7 @@ describe('CJS transform', function() {
   it('var x = { x: require("x"), y: require("y"), ... }', helper.bind(this, 'mapper'))
   it('should ignore requires deepr than top-level', helper.bind(this, 'ignore'))
   it('should preserve comments before and after require\'s', helper.bind(this, 'comments'))
+  it('should hoist require declarations and expressions when "hoist" flag is enabled', helperWithOptions({ hoist: true }).bind(this, 'hoist'))
 });
 
 function helper (name) {
@@ -32,4 +33,13 @@ function helper (name) {
   var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/cjs/' + name + '.after.js')).toString();
   var result = cjsTransform({ source: src }, { jscodeshift: jscodeshift });
   assert.equal(result, expectedSrc);
+}
+
+function helperWithOptions(options) {
+  return function (name) {
+    var src = fs.readFileSync(path.resolve(__dirname, '../fixtures/cjs/' + name + '.before.js')).toString();
+    var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/cjs/' + name + '.after.js')).toString();
+    var result = cjsTransform({ source: src }, { jscodeshift: jscodeshift }, options);
+    assert.equal(result, expectedSrc);
+  }
 }


### PR DESCRIPTION
This PR enables the CJS transformation to hoist `require( ... )` calls from loop and function blocks when the `hoist` flag is specified. A corresponding test case has been created.

Cheers! :)