### PR TITLE
Fixup named export generation when "Literal" keys present

### DIFF
--- a/test/fixtures/named-export-generation/expression.after.js
+++ b/test/fixtures/named-export-generation/expression.after.js
@@ -9,9 +9,11 @@ const exported5 = {
         console.warn('user', user);
     },
 
-    c: {
+    'c': {
         sample: 42
-    }
+    },
+
+    "d": 'is for dinosaur'
 };
 
 export default exported5;
@@ -19,5 +21,6 @@ export default exported5;
 export const {
     a,
     b,
-    c
+    c,
+    d
 } = exported5;

--- a/test/fixtures/named-export-generation/expression.before.js
+++ b/test/fixtures/named-export-generation/expression.before.js
@@ -9,7 +9,9 @@ export default {
         console.warn('user', user);
     },
 
-    c: {
+    'c': {
         sample: 42
-    }
+    },
+
+    "d": 'is for dinosaur'
 };

--- a/transforms/named-export-generation.js
+++ b/transforms/named-export-generation.js
@@ -115,7 +115,11 @@ module.exports = function(file, api, options) {
 
 			literalProps = objectExpression.properties.filter(function(prop) {
 				return (
-					'key' in prop && prop.key.type === 'Identifier' &&
+					// Ignore computed property keys
+					!prop.computed &&
+					('key' in prop &&
+						// Object keys can be identifier or string literals
+						(prop.key.type === 'Identifier' || prop.key.type === 'Literal')) &&
 					'value' in prop && prop.value.type !== 'Identifier'
 				);
 			});
@@ -149,7 +153,9 @@ module.exports = function(file, api, options) {
 		}
 
 		var exportNames = props.map(function(prop) {
-			return prop.key.name;
+			return prop.key.type === 'Literal' ?
+				prop.key.value :
+				prop.key.name;
 		});
 
 		var properties = exportNames.filter(function(name) {


### PR DESCRIPTION
Closes #46

I added some additional checks for keys of "Literal" type and a check for `prop.computed` to ignore computed properties a little more reliably.

I tested this by updating the existing expression fixture to include string keys and then running `npm test` to verify all tests pass.