### PR TITLE
Convert require statements to imports

### DIFF
--- a/test/fixtures/amd_with_require.after.js
+++ b/test/fixtures/amd_with_require.after.js
@@ -1,0 +1,14 @@
+import a from 'a';
+import b from 'b';
+import c from 'c';
+import g from 'g';
+var d, e, f;
+
+// let's define some things
+var myModule = {
+    doStuffWithThings(val) {
+        return a.morgify(val);
+    },
+};
+
+export default myModule;

--- a/test/fixtures/amd_with_require.before.js
+++ b/test/fixtures/amd_with_require.before.js
@@ -1,0 +1,15 @@
+define(function(require) {
+    var a = require('a');
+    var b = require('b');
+    var c = require('c');
+    var d, e, f, g = require('g');
+
+    // let's define some things
+    var myModule = {
+        doStuffWithThings(val) {
+            return a.morgify(val);
+        },
+    };
+
+    return myModule;
+});

--- a/test/transforms/amd.js
+++ b/test/transforms/amd.js
@@ -24,4 +24,11 @@ describe('AMD transform', function() {
     var result = amdTransform({ source: src }, { jscodeshift: jscodeshift });
     assert.equal(result, expectedSrc);
   });
+
+  it('should convert define(function(require) {})', function() {
+    var src = fs.readFileSync(path.resolve(__dirname, '../fixtures/amd_with_require.before.js')).toString();
+    var expectedSrc = fs.readFileSync(path.resolve(__dirname, '../fixtures/amd_with_require.after.js')).toString();
+    var result = amdTransform({ source: src }, { jscodeshift: jscodeshift });
+    assert.equal(result, expectedSrc);
+  });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -281,6 +281,24 @@ describe('util.getRecastConfig', function() {
   });
 })
 
+describe('util.filterRedundantComments', function() {
+  it('should remove comments that already appear in the source comment array', function() {
+    var source = [
+      { value: 'comment one' },
+      { value: 'comment two' },
+      { value: 'comment three' }
+    ];
+
+    var test = [
+      { value: 'comment one' },
+      { value: 'new comment' }
+    ];
+
+    var filtered = utils.filterRedundantComments(source, test);
+    assert.deepEqual(filtered, [{ value: 'new comment' }]);
+  });
+});
+
 /******************************************
  * Test Helpers...
  ******************************************/

--- a/utils/main.js
+++ b/utils/main.js
@@ -252,6 +252,15 @@ var util = {
 
   hasParentOfType: function(node, type) {
     return util.findParentOfType(node, type) !== false;
+  },
+
+  filterRedundantComments: function(commentsOrig, commentsNew) {
+    if (!commentsOrig || !commentsNew) {
+      // return all comments if there were no original ones
+      return commentsNew;
+    }
+    return commentsNew.filter(comment =>
+        !commentsOrig.some(c => c.value === comment.value));
   }
 };
 


### PR DESCRIPTION
Converts 

```js
define(function(require) {
    var a = require('a');
    var b = require('b');

    var stuff = {};
    return stuff;
});
```
into
```js
import a from 'a';
import b from 'b';

var stuff = {};
export default stuff;
```